### PR TITLE
Enable space-infix-ops rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ module.exports = {
     'space-before-blocks': 2,
     'space-before-function-paren': [2, 'never'],
     // 'space-in-parens': 0,
-    // 'space-infix-ops': 0,
+    'space-infix-ops': 2,
     // 'space-unary-ops': 0,
     'spaced-comment': [2, 'always'],
     // 'unicode-bom': 0,


### PR DESCRIPTION
I think we should catch those missing spaces automatically:

![](https://i.imgur.com/e8syKk8.png)

http://eslint.org/docs/rules/space-infix-ops

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/2)
<!-- Reviewable:end -->