### PR TITLE
Allow console.warn and console.error

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = {
     // http://eslint.org/docs/rules/
 
     'no-cond-assign': 0, // eslint:recommended
-    'no-console': 2, // eslint:recommended
+    'no-console': ['error', {allow: ['warn', 'error']}], // eslint:recommended
     'no-constant-condition': 2, // eslint:recommended
     'no-control-regex': 2, // eslint:recommended
     'no-debugger': 2, // eslint:recommended


### PR DESCRIPTION
In order to implement https://github.com/vaadin/vaadin-grid/issues/566 we need to allow `console.warn`. In future we will also need `console.error`.

`console.log` will still throw a linter error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/5)
<!-- Reviewable:end -->
