### PR TITLE
Enable curly rule to force curly brackets for if/for statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = {
     // 'class-methods-use-this': 0,
     // 'complexity': 0,
     // 'consistent-return': 0
-    // 'curly': 0,
+    'curly': 2,
     // 'default-case': 0,
     // 'dot-location': 0,
     // 'dot-notation': 0,


### PR DESCRIPTION
http://eslint.org/docs/rules/curly

currently it's possible to submit if statement without curly brackets:

```js
if (foo)
  bar;
```

This rule will prevent such cases. 

PS. ES6 arrow functions will be still okay, eslint won't complain about something like 

```js
Array.map((a, b) => a > b)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/7)
<!-- Reviewable:end -->
