### PR TITLE
Enable keyword-spacing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = {
     'indent': [2, 2, {'SwitchCase': 1}],
     // 'jsx-quotes': 0,
     'key-spacing': 2,
-    'keyword-spacing': 0,
+    'keyword-spacing': 2,
     // 'line-comment-position': 0,
     'linebreak-style': 2,
     // 'lines-around-comment': 0,


### PR DESCRIPTION
http://eslint.org/docs/rules/keyword-spacing

currently it's possible to submit if/for statements without spaces around keywords:

```js
if(foo) {
  ...
}else {
```

This rule will prevent such cases and force using spaces:

```js
if (foo) {
  ...
} else {
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/8)
<!-- Reviewable:end -->
