### PR TITLE
Enable space-in-parens rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ module.exports = {
     // 'sort-vars': 0,
     'space-before-blocks': 2,
     'space-before-function-paren': [2, 'never'],
-    // 'space-in-parens': 0,
+    'space-in-parens': 2,
     'space-infix-ops': 2,
     // 'space-unary-ops': 0,
     'spaced-comment': [2, 'always'],


### PR DESCRIPTION
This rule is needed to prevent extra whitespaces in cases like this:

```js
if (variable ) {
  //        ^
}
```

Noticed in https://github.com/vaadin/vaadin-upload/pull/218 by @web-padawan 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/9)
<!-- Reviewable:end -->
