### PR TITLE
Enable no-trailing-spaces rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ module.exports = {
     // 'no-restricted-syntax': 0,
     // 'no-tabs': 0,
     // 'no-ternary': 0,
-    // 'no-trailing-spaces': 0,
+    'no-trailing-spaces': 2,
     // 'no-underscore-dangle': 0,
     // 'no-unneeded-ternary': 0,
     // 'no-whitespace-before-property': 0,


### PR DESCRIPTION
Currently it's possible to occasionally submit trailing whitespaces.

Noticed in [vaadin/vaadin-text-field#366](https://github.com/vaadin/vaadin-text-field/pull/166#issuecomment-344532360) by @platosha

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/10)
<!-- Reviewable:end -->
