### PR TITLE
Update eslint peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "index.js"
   ],
   "peerDependencies": {
-    "eslint": "^4.0.0"
+    "eslint": "^5.0.0"
   }
 }


### PR DESCRIPTION
This is needed to eliminate warning since we already updated most of our repos:
```
npm WARN eslint-config-vaadin@0.2.6 requires a peer of eslint@^4.0.0 but none is installed. You must install peer dependencies yourself.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/eslint-config-vaadin/12)
<!-- Reviewable:end -->
