### PR TITLE
fix: export ./index.js as ./index

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "exports": {
     ".": "./index.js",
+    "./index": "./index.js",
     "./imports": "./imports.js",
     "./lit": "./lit.js",
     "./prettier": "./prettier.js",


### PR DESCRIPTION
It seems that we also need to export `./index.js` as `./index` to get rid of the following error:

```
Error: Cannot read config file: /Users/serhii/vaadin/start/node_modules/eslint-config-vaadin/typescript.js
Error: Cannot find module './index'
Require stack:
- /Users/serhii/vaadin/start/node_modules/eslint-config-vaadin/utils/resolve.js
```
