### PR TITLE
fix: add missing @babel/core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "homepage": "https://github.com/vaadin/eslint-config-vaadin#readme",
   "dependencies": {
+    "@babel/core": "^7.20.5",
     "@babel/eslint-parser": "^7.19.1",
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",


### PR DESCRIPTION
## Description

Added a missing `@babel/core` dependency to `package.json` to resolve the error when using `eslint-config-vaadin/javascript`:

```
Error: Failed to load parser '@babel/eslint-parser' declared in '.eslintrc.json » eslint-config-vaadin/javascript': Cannot find module '@babel/core/package.json'
```

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
