### PR TITLE
fix: add chai-friendly/no-unused-expression rule

### DIFF
--- a/src/rules/testing.ts
+++ b/src/rules/testing.ts
@@ -1,3 +1,6 @@
 export = {
   plugins: ['chai-friendly'],
+  rules: {
+    'chai-friendly/no-unused-expressions': 'error',
+  }
 } as const;

--- a/src/rules/testing.ts
+++ b/src/rules/testing.ts
@@ -1,6 +1,8 @@
 export = {
   plugins: ['chai-friendly'],
   rules: {
+    'no-unused-expressions': 'off',
     'chai-friendly/no-unused-expressions': 'error',
+    'max-classes-per-file': 'off',
   }
 } as const;

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,9 +1,9 @@
 const resolve = require('./utils/resolve.js');
 
 export = {
-  extends: ['./rules/testing'].map(resolve),
   overrides: [
     {
+      extends: ['./rules/testing'].map(resolve),
       files: [
         '*.spec.js',
         '*.spec.ts',

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -16,6 +16,7 @@ export = {
       ],
       rules: {
         'max-classes-per-file': 'off',
+        'no-unused-expressions': 'off',
       },
     },
   ],

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -14,10 +14,6 @@ export = {
         '*.test.jsx',
         '*.test.tsx',
       ],
-      rules: {
-        'max-classes-per-file': 'off',
-        'no-unused-expressions': 'off',
-      },
     },
   ],
 } as const;


### PR DESCRIPTION
Just adding `chai-frinedly` to `plugins` isn't enough to make it work: we should also override the ESLint `no-unused-expressions` rule with the plugin's one.
