### PR TITLE
fix: disable typescript-eslint/no-unused-expressions in tests

### DIFF
--- a/src/rules/testing.ts
+++ b/src/rules/testing.ts
@@ -2,6 +2,7 @@ export = {
   plugins: ['chai-friendly'],
   rules: {
     'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions': 'off',
     'chai-friendly/no-unused-expressions': 'error',
     'max-classes-per-file': 'off',
   }


### PR DESCRIPTION
## Description

At the moment, the `chai-friendly` rules conflict with `typescript-eslint/no-unused-expressions` when linting TypeScript files. All the `no-unused-expressions`-like rules should be disabled in `vaadin/testing` in favor of `chai-friendly/no-unused-expressions`.

## Type of change

- [x] Bugfix
