### PR TITLE
fix: add typescript-requiring-type-checking to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "./lit.js",
     "./prettier.js",
     "./testing.js",
-    "./typescript.js"
+    "./typescript.js",
+    "./typescript-requiring-type-checking.js"
   ],
   "exports": {
     ".": "./javascript.js",


### PR DESCRIPTION
## Description

We missed to add the new config entrypoint to `"files"` so it doesn't work 😞 

## Type of change

- Bugfix