### PR TITLE
feat: add sort config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@
 /javascript.js
 /lit.js
 /prettier.js
+/sort.js
 /testing.js
 /typescript.js
 /typescript-requiring-type-checking.js
+/*.tgz

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A config that contains the JavaScript linting rules.
 
 This config requires `vaadin/prettier` which must be added after any other configs.
 
-```js
+```json5
 {
   "extends": [
     "vaadin/javascript",
@@ -42,7 +42,7 @@ A config that extends `vaadin/javascript` with the TypeScript linting rules.
 
 This config requires `vaadin/prettier` which must be added after any other configs.
 
-```js
+```json5
 {
   "extends": [
     "vaadin/typescript",
@@ -62,7 +62,7 @@ This config requires `tsconfig.json` at the project root with the `include` sect
 
 This config requires `vaadin/prettier` which must be added after any other configs.
 
-```js
+```json5
 {
   "parserOptions": {
     "project": "path/to/your/tsconfig.json"
@@ -83,7 +83,7 @@ This config is designed on top of the `eslint-plugin-lit` plugin.
 
 This config is supposed to be used in combination with `vaadin/javascript` or `vaadin/typescript`.
 
-```js
+```json
 {
   "extends": [
     "vaadin/lit"
@@ -99,7 +99,7 @@ This config is designed on top of the `eslint-plugin-import` plugin. Please note
 
 This config is supposed to be used in combination with `vaadin/javascript` or `vaadin/typescript`.
 
-```js
+```json
 {
   "extends": [
     "vaadin/imports"
@@ -113,10 +113,22 @@ A config that overrides some linting rules and sets up the `eslint-plugin-chai-f
 
 This config is supposed to be used in combination with `vaadin/javascript` or `vaadin/typescript`.
 
-```js
+```json
 {
   "extends": [
     "vaadin/testing"
+  ]
+}
+```
+
+### vaadin/sort
+
+A config that enables alphabetical sorting for objects, enums, JSX props, and exports. It serves as a substitute for the ESLint `sort-keys` rule, which lacks an auto-fixer. Please be aware that the ESLint team has a significant reason for not implementing an auto-fixer for this rule (see [here](https://github.com/eslint/eslint/issues/7714#issuecomment-265542433)). Use the config with caution.
+
+```json
+{
+  "extends": [
+    "vaadin/sort"
   ]
 }
 ```
@@ -125,7 +137,7 @@ This config is supposed to be used in combination with `vaadin/javascript` or `v
 
 ### Lit + JavaScript
 
-```js
+```json
 {
   "extends": [
     "vaadin/javascript",
@@ -138,7 +150,7 @@ This config is supposed to be used in combination with `vaadin/javascript` or `v
 
 ### Lit + TypeScript
 
-```js
+```json
 {
   "extends": [
     "vaadin/typescript",
@@ -151,7 +163,7 @@ This config is supposed to be used in combination with `vaadin/javascript` or `v
 
 Or, you can use a more strict config that requires type information:
 
-```js
+```json
 {
   "extends": [
     "vaadin/typescript-requiring-type-checking",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-plugin-chai-friendly": "^0.7.2",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-lit": "^1.8.2",
+        "eslint-plugin-perfectionist": "^1.5.1",
         "eslint-plugin-prettier": "^4.2.1",
         "prettier": "^2.8.4"
       },
@@ -27,7 +28,7 @@
         "puppeteer": "^19.7.5",
         "rimraf": "^4.4.0",
         "tsx": "^3.12.5",
-        "typescript": "^4.9.5"
+        "typescript": "^5.1.6"
       },
       "peerDependencies": {
         "eslint": "^8.24.0",
@@ -1798,6 +1799,150 @@
         "eslint": ">= 5"
       }
     },
+    "node_modules/eslint-plugin-perfectionist": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-perfectionist/-/eslint-plugin-perfectionist-1.5.1.tgz",
+      "integrity": "sha512-PiUrAfGDc/l6MKKUP8qt5RXueC7FZC6F/0j8ijXYU8o3x8o2qUi6zEEYBkId/IiKloIXM5KTD4jrH9833kDNzA==",
+      "dependencies": {
+        "@typescript-eslint/types": "^5.62.0",
+        "@typescript-eslint/utils": "^5.62.0",
+        "is-core-module": "^2.12.1",
+        "json5": "^2.2.3",
+        "minimatch": "^9.0.3",
+        "natural-compare-lite": "^1.4.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eslint-plugin-perfectionist/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
@@ -2771,9 +2916,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -4085,15 +4230,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "./imports-typescript": "./imports-typescript.js",
     "./lit": "./lit.js",
     "./prettier": "./prettier.js",
+    "./sort": "./sort.js",
     "./testing": "./testing.js",
     "./typescript": "./typescript.js",
     "./typescript-requiring-type-checking": "./typescript-requiring-type-checking.js"
@@ -51,6 +52,7 @@
     "./lit.js",
     "./prettier.js",
     "./rules",
+    "./sort.js",
     "./testing.js",
     "./typescript-requiring-type-checking.js",
     "./typescript.js",
@@ -74,6 +76,7 @@
     "eslint-plugin-chai-friendly": "^0.7.2",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-lit": "^1.8.2",
+    "eslint-plugin-perfectionist": "^1.5.1",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.8.4"
   },
@@ -83,7 +86,7 @@
     "puppeteer": "^19.7.5",
     "rimraf": "^4.4.0",
     "tsx": "^3.12.5",
-    "typescript": "^4.9.5"
+    "typescript": "^5.1.6"
   },
   "peerDependencies": {
     "eslint": "^8.24.0",

--- a/src/rules/eslint/suggestions.ts
+++ b/src/rules/eslint/suggestions.ts
@@ -203,7 +203,8 @@ export = {
     'require-yield': 'error',
     // handled by "eslint-plugin-import" rules
     'sort-imports': 'off',
-    'sort-keys': ['error', 'asc', { caseSensitive: true, natural: true }],
+    // handled by "eslint-plugin-perfectionist" rules
+    'sort-keys': 'off',
     // handled by "one-var" rule
     'sort-vars': 'off',
     'spaced-comment': ['error', 'always'],

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -5,23 +5,23 @@ export = {
     'perfectionist/sort-array-includes': 'off',
     // handled by "@typescript-eslint/member-ordering"
     'perfectionist/sort-classes': 'off',
-    'perfectionist/sort-enums': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
-    'perfectionist/sort-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-enums': ['error', { type: 'natural', order: 'asc' }],
+    'perfectionist/sort-exports': ['error', { type: 'natural', order: 'asc' }],
     // handled by "eslint-plugin-import" rules
     'perfectionist/sort-imports': 'off',
     // does not respect "@typescript-eslint/member-ordering" rules
     'perfectionist/sort-interfaces': 'off',
-    'perfectionist/sort-jsx-props': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-jsx-props': ['error', { type: 'natural', order: 'asc' }],
     // disabled by default; enable if necessary
     'perfectionist/sort-map-elements': 'off',
-    'perfectionist/sort-named-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-named-exports': ['error', { type: 'natural', order: 'asc' }],
     // handled by "eslint-plugin-import" rules
     'perfectionist/sort-named-imports': 'off',
     // does not respect "@typescript-eslint/member-ordering" rules
     'perfectionist/sort-object-types': 'off',
-    'perfectionist/sort-objects': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-objects': ['error', { type: 'natural', order: 'asc' }],
     // handled by "@typescript-eslint/sort-type-constituents" and "@typescript-eslint/sort-type-union-intersection-members"
     // rules
-    'perfectionist/sort-union-types': 'off'
+    'perfectionist/sort-union-types': 'off',
   },
 } as const;

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,10 +1,27 @@
 export = {
   plugin: ['perfectionist'],
   rules: {
+    // sorting array will definitely break the code somewhere.
+    'perfectionist/sort-array-includes': 'off',
+    // handled by "@typescript-eslint/member-ordering"
+    'perfectionist/sort-classes': 'off',
     'perfectionist/sort-enums': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
     'perfectionist/sort-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    // handled by "eslint-plugin-import" rules
+    'perfectionist/sort-imports': 'off',
+    // does not respect "@typescript-eslint/member-ordering" rules
+    'perfectionist/sort-interfaces': 'off',
     'perfectionist/sort-jsx-props': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    // disabled by default; enable if necessary
+    'perfectionist/sort-map-elements': 'off',
     'perfectionist/sort-named-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    // handled by "eslint-plugin-import" rules
+    'perfectionist/sort-named-imports': 'off',
+    // does not respect "@typescript-eslint/member-ordering" rules
+    'perfectionist/sort-object-types': 'off',
     'perfectionist/sort-objects': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    // handled by "@typescript-eslint/sort-type-constituents" and "@typescript-eslint/sort-type-union-intersection-members"
+    // rules
+    'perfectionist/sort-union-types': 'off'
   },
 } as const;

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,0 +1,10 @@
+export = {
+  plugin: ['perfectionist'],
+  rules: {
+    'perfectionist/sort-enums': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-jsx-props': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-named-exports': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+    'perfectionist/sort-objects': ['error', { type: 'natural', order: 'asc', 'ignore-case': true }],
+  },
+} as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,15 @@
 {
   "compilerOptions": {
-    "target": "es2021",
+    "esModuleInterop": true,
+    "target": "es2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["es2021", "dom"],
+    "lib": ["es2022", "dom"],
     "strict": true,
-    "importsNotUsedAsValues": "error",
     "noImplicitOverride": true,
     "useDefineForClassFields": true,
-    "useUnknownInCatchVariables": true
+    "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true
   },
-  "include": ["src", "utils"]
+  "include": ["src", "tools"]
 }


### PR DESCRIPTION
This PR replaces the eslint [sort-keys](https://eslint.org/docs/latest/rules/sort-keys) rule with the optional config based on rules from [perfectionist](https://eslint-plugin-perfectionist.azat.io/) plugin.

The config enables the following rules from the plugin:

- [sort-enums](https://eslint-plugin-perfectionist.azat.io/rules/sort-enums),
- [sort-exports](https://eslint-plugin-perfectionist.azat.io/rules/sort-exports),
- [sort-jsx-props](https://eslint-plugin-perfectionist.azat.io/rules/sort-jsx-props),
- [sort-named-exports](https://eslint-plugin-perfectionist.azat.io/rules/sort-named-exports),
- [sort-objects](https://eslint-plugin-perfectionist.azat.io/rules/sort-objects)

Other rules are disabled either because they could break the code, they are already handled by other rules or they conflict with existing rules.

The most important feature of this PR is that the `perfectionist` plugin implements auto-fixers for all its rules which reduces amount of work usually required by `sort-keys` rule.

Since the config introduces some possibilities to break the code (in case it relies on the property order in objects), the config is optional and could be included or avoided by the user's choice. 
