### PR TITLE
feat: enable require-await rule

### DIFF
--- a/src/rules/eslint/suggestions.ts
+++ b/src/rules/eslint/suggestions.ts
@@ -197,8 +197,7 @@ export = {
     // handled by Prettier
     'quote-props': 'off',
     radix: 'error',
-    // forbids returning promises which is not useful
-    'require-await': 'off',
+    'require-await': 'error',
     'require-unicode-regexp': 'error',
     'require-yield': 'error',
     // handled by "eslint-plugin-import" rules


### PR DESCRIPTION
## Description

The PR enables the [`require-await` rule](https://eslint.org/docs/latest/rules/require-await). 

This rule was originally disabled to allow marking functions as async not only when they have an `await` but also when they return a `Promise`. However, since there wasn't any other rule that would enforce async for Promise-returning functions, maintaining consistency of the async keyword for functions was totally up to the developer and often resulted in oversights.

## Type of change


- [x] Feature
