### PR TITLE
fix: move no-mixed-enums to config with type checking

### DIFF
--- a/src/rules/typescript-requiring-type-checking/original.ts
+++ b/src/rules/typescript-requiring-type-checking/original.ts
@@ -38,6 +38,9 @@ export = {
     // Avoid using promises in places not designed to handle them
     // https://typescript-eslint.io/rules/no-misused-promises
     '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: true, checksConditionals: true }],
+    // Disallow enums from having both number and string members.
+    // https://typescript-eslint.io/rules/no-mixed-enums
+    '@typescript-eslint/no-mixed-enums': 'error',
     // Disallow members of unions and intersections that do nothing or override type information.
     // https://typescript-eslint.io/rules/no-redundant-type-constituents
     '@typescript-eslint/no-redundant-type-constituents': 'error',

--- a/src/rules/typescript/original.ts
+++ b/src/rules/typescript/original.ts
@@ -105,9 +105,6 @@ export = {
     // Enforce valid definition of new and constructor
     // https://typescript-eslint.io/rules/no-misused-new
     '@typescript-eslint/no-misused-new': 'error',
-    // Disallow enums from having both number and string members.
-    // https://typescript-eslint.io/rules/no-mixed-enums
-    '@typescript-eslint/no-mixed-enums': 'error',
     // Disallow the use of custom TypeScript modules and namespaces
     // https://typescript-eslint.io/rules/no-namespace
     '@typescript-eslint/no-namespace': ['error', { allowDefinitionFiles: true }],


### PR DESCRIPTION
## Description

Moves `@typescript-eslint/no-mixed-enums` from `vaadin/typescript` to `vaadin/typescript-requiring-type-checking`, as this rule requires type information to run.

## Type of change

- [x] Bugfix
