### PR TITLE
fix: remove parserOptions.project from vaadin/typescript

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,8 +1,5 @@
 export = {
   extends: ['./javascript', './rules/typescript/original', './rules/typescript/extensions'],
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: `${process.cwd()}/tsconfig.json`,
-  },
   plugins: ['@typescript-eslint'],
 } as const;


### PR DESCRIPTION
## Description

The `vaadin/typescript` config is designed to not require type information, so there is no need to specify `parserOptions.project`. In fact, the presence of this property caused errors in projects that don't include all the linted files in their TS config:

```
  0:0  error  Parsing error: ESLint was configured to run on `<tsconfigRootDir>/web-test-runner.config.js` using `parserOptions.project`: /users/vursen/dev/vaadin/web-components/tsconfig.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```

## Type of change

- [x] Bugfix
