### PR TITLE
fix(typescript): use correct file for no-unused-vars

### DIFF
--- a/src/rules/typescript/extensions.ts
+++ b/src/rules/typescript/extensions.ts
@@ -25,7 +25,7 @@ export = {
     '@typescript-eslint/no-restricted-imports': suggestions['no-restricted-imports'],
     '@typescript-eslint/no-shadow': suggestions['no-shadow'],
     '@typescript-eslint/no-unused-expressions': suggestions['no-unused-expressions'],
-    '@typescript-eslint/no-unused-vars': suggestions['no-unused-vars'],
+    '@typescript-eslint/no-unused-vars': possibleProblems['no-unused-vars'],
     '@typescript-eslint/no-use-before-define': [
       'error',
       {


### PR DESCRIPTION
## Description

The original rule is in the `possible-problems` file.

## Type of change

- Bugfix