### PR TITLE
refactor: use defineConfig instead of tseslint.config

### DIFF
--- a/src/imports-typescript.ts
+++ b/src/imports-typescript.ts
@@ -1,15 +1,16 @@
 import { join } from 'path';
+import { defineConfig, type Config } from 'eslint/config';
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
-import importPlugin from 'eslint-plugin-import-x';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import importX from 'eslint-plugin-import-x';
 import rules from './rules/imports.js';
 import { tsExtensions } from './utils.js';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   files: ['**/*.{ts,tsx,mts,cts}'],
   rules,
   plugins: {
-    'import-x': importPlugin,
+    // @ts-expect-error: https://github.com/un-ts/eslint-plugin-import-x/issues/439
+    'import-x': importX,
   },
   settings: {
     'import-x/resolver-next': [

--- a/src/imports.ts
+++ b/src/imports.ts
@@ -1,13 +1,14 @@
-import importPlugin from 'eslint-plugin-import-x';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import importX from 'eslint-plugin-import-x';
 import rules from './rules/imports';
 import { jsExtensions } from './utils.js';
+import { defineConfig, type Config } from 'eslint/config';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   files: ['**/*.{js,jsx,mjs,cjs}'],
   rules,
   plugins: {
-    'import-x': importPlugin,
+    // @ts-expect-error: https://github.com/un-ts/eslint-plugin-import-x/issues/439
+    'import-x': importX,
   },
   languageOptions: {
     parserOptions: {

--- a/src/javascript.ts
+++ b/src/javascript.ts
@@ -1,10 +1,10 @@
 import parser from '@babel/eslint-parser';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
 import possibleProblems from './rules/eslint/possible-problems.js';
 import suggestions from './rules/eslint/suggestions.js';
 import { jsExtensions } from './utils.js';
+import { defineConfig, type Config } from 'eslint/config';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   files: [`**/*.{${jsExtensions.join(',')}}`],
   rules: {
     ...possibleProblems,

--- a/src/lit.ts
+++ b/src/lit.ts
@@ -1,8 +1,8 @@
+import { defineConfig, type Config } from 'eslint/config';
 import lit from 'eslint-plugin-lit';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
 import rules from './rules/lit.js';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   rules,
   plugins: {
     lit,

--- a/src/prettier.ts
+++ b/src/prettier.ts
@@ -1,8 +1,8 @@
+import { defineConfig, type Config } from 'eslint/config';
 import prettierConfig from 'eslint-config-prettier';
 import prettier from 'eslint-plugin-prettier';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
 
-const config: ConfigArray = tsEslint.config(prettierConfig, {
+const config: readonly Config[] = defineConfig(prettierConfig, {
   plugins: {
     prettier,
   },

--- a/src/react-perf.ts
+++ b/src/react-perf.ts
@@ -1,8 +1,8 @@
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import { defineConfig, type Config } from 'eslint/config';
 import reactPerf from 'eslint-plugin-react-perf';
 import rules from './rules/react/react-perf.js';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   plugins: {
     'react-perf': reactPerf,
   },

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,4 +1,4 @@
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import { defineConfig, type Config } from 'eslint/config';
 import react from 'eslint-plugin-react';
 import reactPerf from 'eslint-plugin-react-perf';
 import reactHooks from 'eslint-plugin-react-hooks';
@@ -8,7 +8,7 @@ import reactRules from './rules/react/react.js';
 import reactPerfRules from './rules/react/react-perf.js';
 import reactHooksRules from './rules/react/react-hooks.js';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   plugins: {
     react,
     'react-hooks': reactHooks,

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,7 +1,7 @@
+import { defineConfig, type Config } from 'eslint/config';
 import perfectionist from 'eslint-plugin-perfectionist';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   plugins: {
     perfectionist: perfectionist,
   },

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -1,8 +1,8 @@
+import { defineConfig, type Config } from 'eslint/config';
 import chaiFriendly from 'eslint-plugin-chai-friendly';
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
 import rules from './rules/testing.js';
 
-const config: ConfigArray = tsEslint.config({
+const config: readonly Config[] = defineConfig({
   files: [
     '**/*.spec.js',
     '**/*.spec.ts',

--- a/src/typescript-requiring-type-checking.ts
+++ b/src/typescript-requiring-type-checking.ts
@@ -1,10 +1,9 @@
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import { defineConfig, type Config } from 'eslint/config';
 import extensions from './rules/typescript-requiring-type-checking/extensions.js';
 import original from './rules/typescript-requiring-type-checking/original.js';
 import typescript from './typescript.js';
 
-const config: ConfigArray = tsEslint.config({
-  extends: [typescript],
+const config: readonly Config[] = defineConfig(...typescript, {
   rules: {
     ...extensions,
     ...original,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -1,11 +1,12 @@
-import tsEslint, { type ConfigArray } from 'typescript-eslint';
+import tsEslint from 'typescript-eslint';
 import javascript from './javascript.js';
 import * as extensions from './rules/typescript/extensions.js';
 import * as original from './rules/typescript/original.js';
 import { jsExtensions, tsExtensions } from './utils.js';
+import { defineConfig, type Config } from 'eslint/config';
 
-const config: ConfigArray = tsEslint.config(
-  javascript,
+const config: readonly Config[] = defineConfig(
+  ...javascript,
   tsEslint.configs.base,
   {
     languageOptions: {


### PR DESCRIPTION
This PR updates the previous version of code
```ts
const config: ConfigArray = tsEslint.config();
```
to 
```ts
const config: readonly Config[] = defineConfig();
```
because Eslint introduced `defineConfig` function, and TS-Eslint deprecated their implementation.