### PR TITLE
refactor(typescript): add missing rules & cleanup

### DIFF
--- a/src/rules/typescript-requiring-type-checking/original.ts
+++ b/src/rules/typescript-requiring-type-checking/original.ts
@@ -100,6 +100,9 @@ const rules: Linter.RulesRecord = {
   // Require unary negation to take a number
   // https://typescript-eslint.io/rules/no-unsafe-unary-minus
   '@typescript-eslint/no-unsafe-unary-minus': 'error',
+  // Disallow default values that will never be used.
+  // https://typescript-eslint.io/rules/no-useless-default-assignment
+  '@typescript-eslint/no-useless-default-assignment': 'error',
   // Prefers a non-null assertion over explicit type cast when possible
   // https://typescript-eslint.io/rules/non-nullable-type-assertion-style
   '@typescript-eslint/non-nullable-type-assertion-style': 'error',

--- a/src/rules/typescript/extensions.ts
+++ b/src/rules/typescript/extensions.ts
@@ -10,22 +10,52 @@ export const common: Linter.RulesRecord = {
       ignoreClassesThatImplementAnInterface: true,
     },
   ],
+  // Enforce default parameters to be last
+  // https://typescript-eslint.io/rules/default-param-last
   '@typescript-eslint/default-param-last': suggestions['default-param-last'] ?? 'off',
+  // Require or disallow initialization in variable declarations
+  // https://typescript-eslint.io/rules/init-declarations
   '@typescript-eslint/init-declarations': suggestions['init-declarations'] ?? 'off',
   '@typescript-eslint/max-params': suggestions['max-params'] ?? 'off',
   // Disallow generic Array constructors
   // https://typescript-eslint.io/rules/no-array-constructor
   '@typescript-eslint/no-array-constructor': 'error',
+  // Disallow duplicate class members
+  // https://typescript-eslint.io/rules/no-dupe-class-members
   '@typescript-eslint/no-dupe-class-members': possibleProblems['no-dupe-class-members'] ?? 'off',
+  // Disallow Empty Functions
+  // https://typescript-eslint.io/rules/no-empty-function
   '@typescript-eslint/no-empty-function': suggestions['no-empty-function'] ?? 'off',
+  // Disallow this keywords outside of classes or class-like objects
+  // https://typescript-eslint.io/rules/no-invalid-this
   '@typescript-eslint/no-invalid-this': suggestions['no-invalid-this'] ?? 'off',
+  // Disallow function declarations that contain unsafe references inside loop statements
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-loop-func
   '@typescript-eslint/no-loop-func': suggestions['no-loop-func'] ?? 'off',
+  // Disallows magic numbers
+  // https://typescript-eslint.io/rules/no-magic-numbers
+  // EXPLANATION: Too strict
   '@typescript-eslint/no-magic-numbers': 'off',
+  // Disallow variable redeclaration
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-redeclare
   '@typescript-eslint/no-redeclare': suggestions['no-redeclare'] ?? 'off',
+  // Disallow specified modules when loaded by import
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-restricted-imports
   '@typescript-eslint/no-restricted-imports': suggestions['no-restricted-imports'] ?? 'off',
+  // Disallow variable declarations from shadowing variables declared in the outer scope
+  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow
   '@typescript-eslint/no-shadow': suggestions['no-shadow'] ?? 'off',
+  // Disallow unused expressions
+  // https://typescript-eslint.io/rules/no-unused-expressionss
   '@typescript-eslint/no-unused-expressions': suggestions['no-unused-expressions'] ?? 'off',
+  // Disallow unused private class members.
+  // https://typescript-eslint.io/rules/no-unused-private-class-members
+  '@typescript-eslint/no-unused-private-class-members': possibleProblems['no-unused-private-class-members'] ?? 'off',
+  // Disallow unused variables
+  // https://typescript-eslint.io/rules/no-unused-vars
   '@typescript-eslint/no-unused-vars': possibleProblems['no-unused-vars'] ?? 'off',
+  // Disallow the use of variables before they are defined
+  // https://typescript-eslint.io/rules/no-use-before-define
   '@typescript-eslint/no-use-before-define': [
     'error',
     {
@@ -33,55 +63,30 @@ export const common: Linter.RulesRecord = {
       typedefs: true,
     },
   ],
+  // Disallow unnecessary constructors
+  // https://typescript-eslint.io/rules/no-useless-constructor
   '@typescript-eslint/no-useless-constructor': 'error',
   'class-methods-use-this': 'off',
   'consistent-return': 'off',
-  // Enforce default parameters to be last
-  // https://typescript-eslint.io/rules/default-param-last
   'default-param-last': 'off',
-  // Require or disallow initialization in variable declarations
-  // https://typescript-eslint.io/rules/init-declarations
   'init-declarations': 'off',
   'max-params': 'off',
-  // Disallow duplicate class members
-  // https://typescript-eslint.io/rules/no-dupe-class-members
   'no-dupe-class-members': 'off',
-  // Disallow Empty Functions
-  // https://typescript-eslint.io/rules/no-empty-function
   'no-empty-function': 'off',
-  // Disallow this keywords outside of classes or class-like objects
-  // https://typescript-eslint.io/rules/no-invalid-this
   'no-invalid-this': 'off',
-  // Disallow function declarations that contain unsafe references inside loop statements
-  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-loop-func
   'no-loop-func': 'off',
   // Disallow literal numbers that lose precision
   // https://typescript-eslint.io/rules/no-loss-of-precision
+  // DEPRECATED AND REMOVED FROM CONFIG
   'no-loss-of-precision': 'off',
-  // Disallows magic numbers
-  // https://typescript-eslint.io/rules/no-magic-numbers
-  // EXPLANATION: Too strict
   'no-magic-numbers': 'off',
-  // Disallow variable redeclaration
-  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-redeclare
   'no-redeclare': 'off',
-  // Disallow specified modules when loaded by import
-  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-restricted-imports
   'no-restricted-imports': 'off',
-  // Disallow variable declarations from shadowing variables declared in the outer scope
-  // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow
   'no-shadow': 'off',
-  // Disallow unused expressions
-  // https://typescript-eslint.io/rules/no-unused-expressionss
   'no-unused-expressions': 'off',
-  // Disallow unused variables
-  // https://typescript-eslint.io/rules/no-unused-vars
+  'no-unused-private-class-members': 'off',
   'no-unused-vars': 'off',
-  // Disallow the use of variables before they are defined
-  // https://typescript-eslint.io/rules/no-use-before-define
   'no-use-before-define': 'off',
-  // Disallow unnecessary constructors
-  // https://typescript-eslint.io/rules/no-useless-constructor
   'no-useless-constructor': 'off',
 };
 


### PR DESCRIPTION
Add newly introduced rules:

- `@typescript-eslint/no-useless-default-assignment`
- `@typescript-eslint/no-unused-private-class-members`

Plus small comment cleanup