### PR TITLE
chore: add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "eslint-config-vaadin",
+  "image": "node:25-bookworm-slim",
+  "runArgs": ["--name=eslincfgvaadin_dev"],
+  "containerEnv": {
+    "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD": "1",
+    "BROWSER_HOST": "host.docker.internal",
+    "BROWSER_PORT": "39273"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": false,
+      "installOhMyZsh": false,
+      "installOhMyZshConfig": false
+    }
+  },
+  "remoteUser": "node",
+  "mounts": [
+    {
+      "source": "${localWorkspaceFolderBasename}_nodemodules",
+      "target": "${containerWorkspaceFolder}/node_modules",
+      "type": "volume"
+    }
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": ["esbenp.prettier-vscode", "EditorConfig.EditorConfig", "YoavBls.pretty-ts-errors"]
+    }
+  },
+  "postCreateCommand": "sudo chown -R node:node /workspaces/eslint-config-vaadin"
+}

--- a/tools/missing-rule-checker/index.ts
+++ b/tools/missing-rule-checker/index.ts
@@ -1,14 +1,26 @@
-import puppeteer from 'puppeteer-core';
+import dns from 'node:dns/promises';
+import puppeteer, { type Browser } from 'puppeteer-core';
 import checkEslint from './eslint.js';
 import checkImports from './imports.js';
 import checkTypeScript from './typescript.js';
 
-if (!process.env['CHROME_BIN']) {
-  throw new Error('"CHROME_BIN" environment variable is not set');
-}
-
 try {
-  const browser = await puppeteer.launch({ headless: true, executablePath: process.env['CHROME_BIN'] });
+  let browser: Browser;
+
+  if (process.env['CHROME_BIN']) {
+    browser = await puppeteer.launch({
+      headless: true,
+      executablePath: process.env['CHROME_BIN'],
+    });
+  } else if (process.env['BROWSER_HOST'] && process.env['BROWSER_PORT']) {
+    const { address } = await dns.lookup(process.env['BROWSER_HOST']);
+
+    browser = await puppeteer.connect({
+      browserURL: `http://${address}:${process.env['BROWSER_PORT']}`,
+    });
+  } else {
+    throw new Error('Neither "CHROME_BIN" nor "BROWSER_URL" environment variable is set');
+  }
 
   const results = await Promise.all([checkEslint(browser), checkTypeScript(browser), checkImports(browser)]);
 


### PR DESCRIPTION
This PR adds a [devcontainer](https://containers.dev/) to isolate host machine from malicious npm packages and move development to a clean and safe environment. 

Adding a whole chrome instance to the container looks a bit overhead for me. So, isntead I decided to add some tweaks for puppeteer to allow connection to the special session of the host browser. That session has to be started on the host manually via the following command:
```bash
$ chrome --headless=new --remote-debugging-port=39273
```
You can add more flags if you want. Then, `npm run check` command becomes awailable.

**NOTE**: I have run devcontainer in Docker only. I cannot guarantee it works in the Podman environment.
**NOTE**: If you don't use devcontainer, then the original approach using `CHROME_BIN` environment variable will work.